### PR TITLE
configure 4 o'clock as reference time of AORI.

### DIFF
--- a/scripts/github.coffee
+++ b/scripts/github.coffee
@@ -66,7 +66,7 @@ module.exports = (robot) ->
       robot.send TARGET_ROOM, message
 
   existsBetweenRefDateRange =(createAt, referenceDateFrom, referenceDateTo) ->
-  return referenceDateFrom.isBefore(createAt) and referenceDateTo.isAfter(createAt)
+    return referenceDateFrom.isBefore(createAt) and referenceDateTo.isAfter(createAt)
 
   getAoriReferenceDate = (checkingDate, configuredReferenceTime = AORI_REF_TIME) ->
     if checkingDate.isAfter(moment(configuredReferenceTime))

--- a/scripts/github.coffee
+++ b/scripts/github.coffee
@@ -27,16 +27,30 @@ AORI_MONKU = ["今日は草生やしてないっすけど良いんすか？ｗ�
 module.exports = (robot) ->
 
   new cron('0 0 22 * * *', () ->
-    dateFrom = moment().startOf('day')
-    dateTo = moment().endOf('day')
+    refTime = {hour: 4}
+    now = moment()
+    if now.isAfter(moment(refTime))
+      dateFrom = moment(refTime)
+      dateTo = moment(refTime).add(1, 'days')
+    else
+      dateFrom = moment(refTime).subtract(1, 'days')
+      dateTo = moment(refTime)
     for user, value of GITHUB_USERS
       checkUserCommits(user)
   ).start()
 
   robot.respond /github checkCommits (.*)/i, (msg) ->
     user = msg.match[1]
-    dateFrom = moment().startOf('day')
-    dateTo = moment().endOf('day')
+
+    refTime = {hour: 4}
+    now = moment()
+    if now.isAfter(moment(refTime))
+      dateFrom = moment(refTime)
+      dateTo = moment(refTime).add(1, 'days')
+    else
+      dateFrom = moment(refTime).subtract(1, 'days')
+      dateTo = moment(refTime)
+
     checkUserCommits(user, dateFrom, dateTo)
 
   # 指定された期間内にコミットイベント（プッシュイベントがない場合は煽る）
@@ -53,7 +67,7 @@ module.exports = (robot) ->
         unless event.type == "PushEvent"
           continue
         createAt = moment(event.created_at)
-        unless dateFrom.IsAfter(createAt) and dateTo.IsBefore(createAt)
+        unless dateFrom.isAfter(createAt) and dateTo.isBefore(createAt)
           continue
         commitCount++
       if commitCount > 0


### PR DESCRIPTION
## 概要
- 煽りを入れる基準時刻を 0 時から 4時にして実態を反映

## 詳細
### やったこと
- 4時から翌日4時を設定
- 0時から4時にコマンドを手動実行した場合、前の日の4時からその日の4時で判定
- なんかメソッド(isAfter(), isBefore() ) でエラーが出た & メソッド名のスタイルが一般的でないので修正

### レビューポイント
- ロジックあってんのか？
- moment.js わからんから間違ってたら教えてください

### 参考にしたURL
- https://momentjs.com/docs/
- https://qiita.com/ue5963/items/729c76fe5b821e5c504e
- https://its-office.jp/blog/js/2016/04/02/moment.html

## 最後に一言コメント
草を生やすことが正義だ

