### PR TITLE
煽り時にメンションが飛ぶように変更

### DIFF
--- a/scripts/tachikoma.coffee
+++ b/scripts/tachikoma.coffee
@@ -43,5 +43,5 @@ TACHIKOMA_WORDS = [
 
 module.exports = (robot) ->
 
-	robot.hear /[たちこま|タチコマ/tachikoma]/i, (msg) -> 
+	robot.hear /たちこま|タチコマ|tachikoma/i, (msg) -> 
 		msg.send msg.random TACHIKOMA_WORDS


### PR DESCRIPTION
## 概要
煽り時に@Niwa.Takeruを付けていたが、メンションが飛んでいなかったものを改善

## 詳細
### やったこと
- @Niwa.Takeruとしていたところを<@slackId>として、メンションが飛ぶに変更 

### やらなかったこと
- Userに関してクラスを作って分かりやすくしたかったが面倒だったので今回はやらず。

### 参考にしたURL
- [Slackでのメンションのとばし方。](https://api.slack.com/docs/message-formatting#how_to_display_formatted_messages)

## 最後に一言コメント
タチコマコマンドの正規表現ミスってて、全部のメッセージに反応するうざい仕様になっていたｗｗ
